### PR TITLE
com.gm.chevrolet.nomad.ownership

### DIFF
--- a/issues.txt
+++ b/issues.txt
@@ -52,3 +52,7 @@ lh3.googleusercontent.com
 swisslife.ch
 //https://forum.adguard.com/index.php?threads/adguard-%D0%B4%D0%BB%D1%8F-windows-%D0%A0%D0%B5%D0%BB%D0%B8%D0%B7-%D0%BA%D0%B0%D0%BD%D0%B4%D0%B8%D0%B4%D0%B0%D1%82-6-2-437-2171.26944/#post-165902
 ssh.cloud.google.com
+// https://github.com/AdguardTeam/AdguardForAndroid/issues/1867
+generalmotorscorporation.sc.omtrdc.net
+api.gm.com
+gmmobileservices.gm.com


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardForAndroid/issues/1867
myChevrolet API was added to the default https exclusions list