### PR TITLE
com.fiverr.fiverr -- HTTPS filtering compatibility

### DIFF
--- a/issues.txt
+++ b/issues.txt
@@ -56,3 +56,5 @@ ssh.cloud.google.com
 generalmotorscorporation.sc.omtrdc.net
 api.gm.com
 gmmobileservices.gm.com
+https://github.com/AdguardTeam/AdguardForAndroid/issues/1897
+ssl580930.cloudflaressl.com


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardForAndroid/issues/1897
Domain for com.fiverr.fiverr was added to the exclusions