### PR TITLE
Fix online.standardlife.com #36791

### DIFF
--- a/banks.txt
+++ b/banks.txt
@@ -1,6 +1,7 @@
 //
 // Adguard HTTPS exclusions: banks and financial services
 //
+online.standardlife.com
 payments.olx.com
 mirconnect.ru
 key.com


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/36791

Unsure if we should exclude full page or only subdomain.