### PR TITLE
Add BNP bank exclusion.

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -263,6 +263,7 @@ bmwbank.de
 bn.aliorbank.pl
 bnkv.ru
 bnpparibas.com
+bnpparibas.pl
 bnpparibasfortis.be
 bobibanking.com
 bodenseebank.de


### PR DESCRIPTION
Hi,

As a former developer of BNP we'd like to request our app exclusion from your list. Currently, our clients and your users are unable to access our application: https://play.google.com/store/apps/details?id=com.finanteq.finance.bgz&hl=pl