### PR TITLE
Fix #215 postacertificata.lextel.it

### DIFF
--- a/exclusions/issues.txt
+++ b/exclusions/issues.txt
@@ -1,6 +1,8 @@
 //
 // HTTPS exclusions, necessary to resolve specific issues
 //
+// https://github.com/AdguardTeam/AdguardFilters/issues/43468
+postacertificata.lextel.it
 // https://github.com/AdguardTeam/HttpsExclusions/issues/203
 console.cloud.google.com
 // https://github.com/AdguardTeam/AdguardFilters/issues/35553


### PR DESCRIPTION
This service has no ads. It is broken when HTTPS filtering only is enabled(checked remotely).