### PR TITLE
nationwide.co.uk typo

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -3082,7 +3082,7 @@ op.fi
 s-pankki.fi
 verkkopalkka.maventa.fi
 nccc.com.tw
-nationwide.co.u
+nationwide.co.uk
 monzo.com
 online.gemvisa.com.au
 bancodebogota.com


### PR DESCRIPTION
https://github.com/AdguardTeam/HttpsExclusions/issues/173