### PR TITLE
Add buyway.be to banks.txt

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -374,6 +374,7 @@ budapestbank.hu
 bunq.app
 bus.ideabank.ua
 businessonline.ge
+buyway.be
 bv-activebanking.de
 byblosbank.com.lb
 bystrobank.ru


### PR DESCRIPTION
### This:
- adds **Buy Way Belgium** credit institution (`buyway.be`) to banks.txt.
&nbsp;

<details>
<summary>Read more …</summary>

# :earth_africa: Links
:fast_forward: See https://www.buyway.be/
:arrow_right_hook: … and information about the company on the French Wikipedia page [here](https://fr.wikipedia.org/wiki/Buy_Way_Personal_Finance).
  - Own homebanking @ https://services.buyway.be/homebanking/ ([Android](https://play.google.com/store/apps/details?id=be.buyway.buywaymobile&hl=en) and [iOS](https://apps.apple.com/be/app/buy-way/id1514369217?l=en) apps).
  - But also used by some banks like **BNP Paribas Fortis (:belgium:)** to manage [their prepaid Mastercard](https://services.buyway.be/bnpparibasfortisprepaid/) _(their [Android](https://play.google.com/store/apps/details?id=be.bnpparibasfortis.bnppfprepaid&hl=en) and [iOS](https://apps.apple.com/be/app/bnp-paribas-fortis-prepaid/id1069318050?l=en) apps also use this domain name, at least I checked on the Android one)_.

# :information_source: Remark
`buyway.lu` ([go there](https://www.buyway.lu/)) was finally not added because their link "Homebanking" leads to [https://services.buyway.be/homebanking/104lu/](https://services.buyway.be/homebanking/104lu/).
</details>
