### PR TITLE
Add carrefourfinance.be to banks.txt

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -398,6 +398,7 @@ card2cash.unistream.ru
 cardhouse.ncc-uc.ru
 cardpay.com
 cardtocard.dvbank.ua
+carrefourfinance.be
 castell-bank.de
 cathaybk.com.tw
 cav.receita.fazenda.gov.br


### PR DESCRIPTION
### This:
- adds **Carrefour Finance Belgium (Fimaser)** credit institution (`carrefourfinance.be`) to banks.txt.
&nbsp;

<details>
<summary>Read more …</summary>

# :earth_africa: Links
:fast_forward: See https://www.carrefourfinance.be/
:arrow_right_hook: … and information about the company on [this page](https://www.carrefourfinance.be/societe_de_credits.html) (FR) or [this page](https://www.carrefourfinance.be/over_ons.html) (NL).
  - Own homebanking @ https://homebanking.carrefourfinance.be/homebanking/ ([Android](https://play.google.com/store/apps/details?id=be.fimaser.smartphone&hl=en) and [iOS](https://apps.apple.com/be/app/carrefour-finance/id1131390389?l=en) apps).
</details>