### PR TITLE
Unqualified guesswork fix for AdguardFilters/issues/73074 + Removed duplicates

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -20,6 +20,7 @@
 3dsecure.csas.cz
 3dsecure.gpwebpay.com
 3dsecure.icicibank.com
+3dsecure.no
 53.com
 60.251.84.21
 95.56.246.182
@@ -621,6 +622,7 @@ diamantpay.com.ua
 die-raiffeisenbank.de
 die-vrbank.de
 diebank.de
+difi.no
 digid.nl
 digital.noorbank.com
 dino.tzero.com
@@ -1935,6 +1937,7 @@ psd-rhein-ruhr.de
 psd-rheinneckarsaar.de
 psd-westfalen-lippe.de
 psdbank-ht.de
+pvu.nets.no
 qantasmoney.com
 qiwi.com
 qiwi.ru
@@ -2422,6 +2425,7 @@ shpd.motivtelecom.ru
 siab.ru
 sibank.ru
 sibes.omsk.ru
+signicat.com
 signin.ebay.ca
 signin.ebay.co.uk
 signin.ebay.com

--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -215,8 +215,8 @@ bankhaus-plump.de
 bankia.es
 bankid.no
 bankid.org.ua
-bankidnorge.no
 bankidapis.no
+bankidnorge.no
 banking-gefa-bank.de
 banking-merkur-bank.de
 banking-suedwestbank.de

--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -86,15 +86,12 @@ alorbank.ru
 alpari.ru
 alpha.gr
 alphabank.ro
-alphabank.ro
-alrayanbank.co.uk
 alrayanbank.co.uk
 altbank.com
 alxinger-bank.de
 ambank.amonline.com.my
 ambank.com.my
 amerantbank.com
-americanexpress.com
 americanexpress.com
 amp.com.au
 amrahbank.az
@@ -153,7 +150,6 @@ bancaribe.com.ve
 bancnetonline.com
 banco.bradesco
 bancoactivo.com
-bancoagrario.gov.co
 bancoagrario.gov.co
 bancobrasil.com.br
 bancocajasocial.com
@@ -516,7 +512,6 @@ co-operativebank.co.uk
 coastal24.com
 cobinhood.com
 coinbase.com
-coinbase.com
 coinspot.com.au
 colpatria.com
 colpatria.com.co
@@ -537,7 +532,6 @@ corporate.patriabank.ro
 correqts.kedrbank.com
 cotabank.com.tw
 county2.riverbank.co.ke
-coventrybuildingsociety.co.uk
 coventrybuildingsociety.co.uk
 cp.bluesnap.com
 credicard.com.br
@@ -771,7 +765,6 @@ foehr-amrumer-bank.de
 foerde-sparkasse.de
 fondsdepotbank.de
 forabank.ru
-forex.se
 forex.se
 forsakringskassan.se
 fortuneo.fr
@@ -1207,8 +1200,6 @@ info.cyberplat.ru
 info.deltacredit.ru
 info.metib.ru
 ing-diba.de
-ing-diba.de
-ing.com.au
 ing.com.au
 ing.de
 ing.es
@@ -1225,7 +1216,6 @@ intellectmoney.ru
 interactivebrokers.co.uk
 interactivebrokers.com
 intercommerz.ru
-internet-banking.dbs.com.sg
 internet-banking.dbs.com.sg
 internet-banking.dbsbank.in
 internet-banking.hk.dbs.com
@@ -1386,7 +1376,6 @@ kz.shinhanglobal.com
 labanquepostale.fr
 landbank-horlofftal.de
 landbank.com.tw
-lansforsakringar.se
 lansforsakringar.se
 leaseplanbank.de
 leboutique.com
@@ -1592,8 +1581,6 @@ neteller.com
 netpnb.com
 netsafe.hdfcbank.com
 nettbank2.danskebank.no
-nettbank2.danskebank.no
-nettbanken.nordea.no
 nettbanken.nordea.no
 nettbedriften.evry.com
 netteller.com
@@ -1608,7 +1595,6 @@ nobaeg.de
 nokss.ru
 nordea.com
 nordea.ru
-nordea.se
 nordea.se
 nordeanetbank.dk
 nordthueringer-volksbank.de
@@ -1959,7 +1945,6 @@ qweb.quercia.com
 r-volksbank.de
 rabobank.co.nz
 rabobank.nl
-rabodirect.de
 rabodirect.de
 radabank.com.ua
 raiba-aiglsbach.de
@@ -2340,7 +2325,6 @@ santander.nl
 santanderbank.com
 santanderconsumer.se
 sbab.se
-sbab.se
 sberbank-ast.ru
 sberbank.hu
 sberbank.kz
@@ -2449,7 +2433,6 @@ simplii.com
 sinopac.com
 sistemagorod.ru
 sk-westerwald-sieg.de
-skandia.se
 skandia.se
 skb-badhomburg.de
 skb-buehlertal.de

--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -1173,11 +1173,15 @@ iclient3.devoncredit.ru
 iclients.baltinvest.ru
 icon25-bank.com
 icorner.ch
+id.banknorwegian.no
+id.santanderconsumer.no
 idbi.com
 idbibank.co.in
 idbibank.com
 ideabank24.by
 ideaonline.ua
+ident.nets.eu
+identity.banknorwegian.no
 ifobs.bankcenter.com.ua
 ifobs.dvbank.ua
 ifobs.kredobank.com.ua
@@ -1423,6 +1427,7 @@ login.e-taxes.gov.az
 login.ingbank.pl
 login.optumbank.com
 login.sebbank.ru
+login.sparebank1.no
 lovizaim.ru
 lzo.com
 m24.comertbank.md
@@ -1484,6 +1489,7 @@ migs.mastercard.com.au
 mijn.ing.nl
 minavardkontakter.se
 minbank.ru
+minnettbank.santanderconsumer.no
 minpension.se
 mirconnect.ru
 mitfcu.org
@@ -1586,7 +1592,10 @@ neteller.com
 netpnb.com
 netsafe.hdfcbank.com
 nettbank2.danskebank.no
+nettbank2.danskebank.no
 nettbanken.nordea.no
+nettbanken.nordea.no
+nettbedriften.evry.com
 netteller.com
 new.mybank.by
 new.permatanet.com
@@ -2394,6 +2403,7 @@ secure.sirena-travel.ru
 secure.tcsbank.ru
 secure.ucs.su
 secure.upc.ua
+secure.ya.no
 secure3.nsandi.com
 secure4.segpay.com
 secure5.arcot.com
@@ -2407,6 +2417,7 @@ securitybank.com
 seebachgrund.de
 seeligerbank.de
 selfbank.es
+selfservice.ikano.no
 selfwealth.com.au
 sendwyre.com
 seninbankan.com.tr
@@ -3421,6 +3432,7 @@ xcitybank.com.ua
 xn--80aae3af7av6a7a.xn--p1ai
 xn--httenberger-bank-jzb.de
 xpi.com.br
+yanettbank.ya.no
 yapikredi.com.az
 yapikredi.com.tr
 yarbank.ru

--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -215,6 +215,8 @@ bankhaus-plump.de
 bankia.es
 bankid.no
 bankid.org.ua
+bankidnorge.no
+bankidapis.no
 banking-gefa-bank.de
 banking-merkur-bank.de
 banking-suedwestbank.de

--- a/exclusions/sensitive.txt
+++ b/exclusions/sensitive.txt
@@ -101,3 +101,7 @@ kashflow.com
 prestigecu.org
 myob.com
 hotdoc.com.au
+// https://github.com/AdguardTeam/HttpsExclusions/pull/372
+checkout.bambora.com
+id.biltema.com
+besoklegen.no


### PR DESCRIPTION
Given the (at the time of writing) very limited information provided for that issue, I'm attempting to fix it by adding more HTTPS exceptions for sites that often host BankID login fields, similar to the previously added `bankid.no` and `portalbank.no`.

* Fix https://github.com/AdguardTeam/AdguardFilters/issues/73074