### PR TITLE
mozilla.org - removed unnecessary HTTPS exclusion

### DIFF
--- a/exclusions/firefox.txt
+++ b/exclusions/firefox.txt
@@ -9,7 +9,6 @@ chrome.adtidy.org
 dl.dropboxusercontent.com
 eff.org
 mozilla.net
-mozilla.org
 mozilla.com
 d13itkw33a7sus.cloudfront.net
 stickypassword.com


### PR DESCRIPTION
HTTPS exclusion prevents tracking blocking:
https://github.com/AdguardTeam/AdguardFilters/commit/3af7a88685be1fd05facb90414899d1be2ae82d1
https://github.com/AdguardTeam/AdguardFilters/commit/0879b87f33690c49cce787592c60139382614de0

Related to https://github.com/AdguardTeam/HttpsExclusions/issues/129
Before approve, must be checked:
- extensions install/update;
- profile sync;
- app update.