### PR TITLE
Exclude Bank Website - paragonbank.co.uk

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -1930,6 +1930,7 @@ pagbrasil.com
 pagseguro.uol.com.br
 palmettohealthcu.org
 papara.com
+paragonbank.co.uk
 paranabanco.com.br
 paranabanco.com.br
 pashabank.az


### PR DESCRIPTION
The bank uses both

online.paragonbank.co.uk
&
paragonbank.co.uk

So I added paragonbank.co.uk, just for your information.

I saw the bank from this report: https://github.com/AdguardTeam/AdguardFilters/issues/123420