### PR TITLE
issue #win4595 (AdGuard does not automatically import CA for Firefox)

### DIFF
--- a/exclusions/firefox.txt
+++ b/exclusions/firefox.txt
@@ -21,3 +21,5 @@ static.adguard.com
 agrd.io
 // 1Paassword extension
 cdn.agilebits.com
+// https://github.com/AdguardTeam/AdguardForWindows/issues/4595
+aus5.mozilla.org


### PR DESCRIPTION
related to https://github.com/AdguardTeam/AdguardForWindows/issues/4595