### PR TITLE
Delete mapcam

### DIFF
--- a/exclusions/issues.txt
+++ b/exclusions/issues.txt
@@ -21,8 +21,6 @@ charts.profinance.ru
 e-xacbank.com
 // https://github.com/AdguardTeam/HttpsExclusions/issues/85
 boxcryptor.com
-// https://github.com/AdguardTeam/AdguardFilters/issues/9901
-mapcam.info
 // https://github.com/AdguardTeam/AdguardFilters/issues/9131
 tknauth.spmode.ne.jp
 // https://github.com/AdguardTeam/AdguardFilters/issues/7531


### PR DESCRIPTION
https://mapcam.info/speedcam/ (see [mapcam issue](https://github.com/AdguardTeam/AdguardFilters/issues/9901)) can be accessed on mac and windows without adding mapcam.info to https exclusions