### PR TITLE
Exclusions for mostly Norwegian Android apps that have major problems with HTTPS filtering

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -3417,6 +3417,7 @@ vicsuper.com.au
 vietcombank.com.vn
 vietinbank.vn
 vip.ritzbank.ru
+vipps.no
 virginmoney.com
 virtualbanking.mcb.com.lk
 viseca.ch

--- a/exclusions/issues.txt
+++ b/exclusions/issues.txt
@@ -112,3 +112,14 @@ link.adtidy.org
 api.adguard.org
 // https://github.com/AdguardTeam/CoreLibs/issues/1693
 voipnx-saturn.line-apps.com
+// https://github.com/AdguardTeam/HttpsExclusions/pull/578
+api.coop.no
+bestill.egon.no
+api.source.no
+tnfba-static2.telenorcdn.net
+tnfba-static.telenorcdn.net
+p-sdp-mob.tvs.telenor.net
+p-sdp-mqtt.tvs.telenor.net
+nfk.wtw.no
+mobilemaps-pa-gz.googleapis.com
+googlehomefoyer-pa.googleapis.com

--- a/exclusions/issues.txt
+++ b/exclusions/issues.txt
@@ -116,10 +116,8 @@ voipnx-saturn.line-apps.com
 api.coop.no
 bestill.egon.no
 api.source.no
-tnfba-static2.telenorcdn.net
-tnfba-static.telenorcdn.net
-p-sdp-mob.tvs.telenor.net
-p-sdp-mqtt.tvs.telenor.net
+telenorcdn.net
+tvs.telenor.net
 nfk.wtw.no
 mobilemaps-pa-gz.googleapis.com
 googlehomefoyer-pa.googleapis.com


### PR DESCRIPTION
Attempts to prevent breaking the following kind of stuff:

### Android apps that seem substantially broken unless their domains are whitelisted:
#### no.coop.members (Store campaign E-papers won't load)
- api.coop.no
#### no.egon.app (Doesn't get past the splash screen)
- bestill.egon.no
#### no.source.pirbadet (Throws errors about failing to load user profiles, despite seemingly reaching the ticket order page)
- api.source.no
#### no.reisnordland.reis.production ("Service unavailable, try again later.")
- nfk.wtw.no
#### com.canaldigital.twe (Doesn't load the media menus besides the "Continue watching" row. Playing it safe by whitelisting both of its core domains.)
- telenorcdn.net
- tvs.telenor.net
#### com.google.android.apps.adm (If I need to find my phone, then it's safe to say that the fewer chancers there are for the phone to fail to connect to anything, the better)
- mobilemaps-pa-gz.googleapis.com
- googlehomefoyer-pa.googleapis.com
#### no.dnb.vipps (Bank. *May* also affect fi.danskebank.mobilepay and dk.danskebank.mobilepay, but hard to tell for sure.)
- vipps.no

I acquitted quite a few other apps, including ones one would presume would fail, but which didn't, including (but not limited to) no.mittatb.store, se.sj.android, and no.posten.sporing.controller.