### PR TITLE
Add new T-Bank domain

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -3150,6 +3150,7 @@ tarjetacencosud.cl
 tas24.ua
 taunussparkasse.de
 tavrich.ru
+tbank.ru
 tbank.trustbank.by
 tbb.com.tw
 tbb.ee


### PR DESCRIPTION
I left `tinkoff.ru` because the personal account still uses the old domain.