### PR TITLE
Add Bank Jago

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -1428,6 +1428,7 @@ ivybank.ru
 iw.unistream.ru
 izhcard.ru
 jaerensparebank.no
+jago.com
 jbf.no
 jenius.com
 jihsunbank.com.tw


### PR DESCRIPTION
Bank Jago (https://jago.com) is one of digital banks in Indonesia.