### PR TITLE
fix: add vwfs.de to banks

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -3756,6 +3756,7 @@ vtbdirekt.de
 vtkbank.ru
 vvb-maingau.de
 vvrb.de
+vwfs.de
 vystarcu.org
 w-saarplus.de
 waldecker-bank.de


### PR DESCRIPTION
Hi, I noticed that the domain [vwfs.de](https://vwfs.de) of the Bank of the German automotive brand Volkswagen [vwfs (Volkswagen financial services)](https://www.vwfs.de) is not listed as an exclusion. I just went ahead and created a PR to add it, I hope that's ok. :)