### PR TITLE
fix Play Integrity API Checker: play-integrity-checker-api.vercel.app

### DIFF
--- a/exclusions/android.txt
+++ b/exclusions/android.txt
@@ -253,3 +253,5 @@ hk.enel.it
 cdc.daikin.eu
 // https://github.com/AdguardTeam/AdguardForAndroid/issues/5096
 wallpaperapi.sofa.opera-api2.com
+// https://github.com/AdguardTeam/HttpsExclusions/pull/665
+play-integrity-checker-api.vercel.app$app=gr.nikolasspyr.integritycheck


### PR DESCRIPTION
This application is used to check the Integrity API of Google Play. It calls the domain `play-integrity-checker-api.vercel.app` for checking. However, if HTTPS filtering is applied, there will be problems with its certificate (as shown in the figure). So it should be excluded from the HTTPS filtering list.

![Picture](https://github.com/user-attachments/assets/6bcd02cf-dcb5-434b-9f95-20cf432fccf1)
