### PR TITLE
Add ChatGPT Atlas login to Mac exclusions

### DIFF
--- a/exclusions/mac.txt
+++ b/exclusions/mac.txt
@@ -17,7 +17,7 @@ check.svyaznoy.ru
 www.re-store.ru
 // Temporary, see https://github.com/AdguardTeam/CoreLibs/issues/1097
 www.antonioli.eu
-// // Temporary, see https://github.com/AdguardTeam/CoreLibs/issues/1506
+// Temporary, see https://github.com/AdguardTeam/CoreLibs/issues/1506
 raindrop.io
 // ChatGPT Atlas login issues https://github.com/AdguardTeam/CoreLibs/issues/2043
 auth.openai.com$app=com.openai.atlas


### PR DESCRIPTION
Added new exclusions related to OpenAI Atlas login issues. Related to https://github.com/AdguardTeam/CoreLibs/issues/2043