### PR TITLE
fix westpac.com.au

### DIFF
--- a/exclusions/banks.txt
+++ b/exclusions/banks.txt
@@ -269,7 +269,6 @@ banking.servus.ca
 banking.sparkasse-mittelsachsen.de
 banking.sparkasse-nienburg.de
 banking.sparkasse-prignitz.de
-banking.westpac.com.au
 bankingportal.sparkasse-koelnbonn.de
 bankinter.com
 banklenz.de
@@ -3836,6 +3835,7 @@ westconsincu.org
 westerwaldbank.de
 westkreis.de
 westpac.co.nz
+westpac.com.au
 wfc.sebank.se
 wideup.net
 widiba.it


### PR DESCRIPTION
Missing the Australian domain for Westpac, as the New Zealand domain is already present.

Will resolve:
- https://github.com/AdguardTeam/AdguardFilters/issues/236213

_(Credit to @zloyden)_